### PR TITLE
[#151516133] Add cdn-cron job

### DIFF
--- a/jobs/cdn-cron/monit
+++ b/jobs/cdn-cron/monit
@@ -1,0 +1,9 @@
+<% if spec.bootstrap %>
+check process cdn-cron
+  with pidfile /var/vcap/sys/run/cdn-cron/cdn-cron.pid
+  start program "/var/vcap/packages/bosh-helpers/monit_debugger cdn-cron-ctl '/var/vcap/jobs/cdn-cron/bin/cdn-cron-ctl start'"
+  stop program "/var/vcap/packages/bosh-helpers/monit_debugger cdn-cron-ctl '/var/vcap/jobs/cdn-cron/bin/cdn-cron-ctl stop'"
+  group vcap
+<% else %>
+# Job disabled on VM index > 0.
+<% end %>

--- a/jobs/cdn-cron/spec
+++ b/jobs/cdn-cron/spec
@@ -1,0 +1,53 @@
+---
+name: cdn-cron
+templates:
+  bin/job_properties.sh.erb: bin/job_properties.sh
+  bin/cdn-cron-ctl.erb: bin/cdn-cron-ctl
+
+packages:
+  - bosh-helpers
+  - cdn-broker
+
+properties:
+  cdn-broker.port:
+    description: "Broker Listen Port"
+    default: 3000
+  cdn-broker.broker_username:
+    description: "The username for basic auth between the Cloud Controller and the broker"
+    default: "cdn-broker"
+  cdn-broker.broker_password:
+    description: "The password for basic auth between the Cloud Controller and the broker"
+  cdn-broker.database_url:
+    description: "Broker Database URL"
+  cdn-broker.email:
+    description: "An email for generating the cert"
+  cdn-broker.acme_url:
+    description: "ACME url used for cert generation. Can be a staging URL or a production one for real certs."
+  cdn-broker.bucket:
+    description: "Broker bucket, used to store certstrap HTTP challenges. The broker needs put and delete permissions and the items in it need to be publicly readable."
+  cdn-broker.iam_path_prefix:
+    description: "IAM path prefix used for naming certs"
+    default: "letsencrypt"
+  cdn-broker.cloudfront_prefix:
+    description: "The name prefix for CloudFront distributions created by the broker"
+  cdn-broker.aws_access_key_id:
+    description: "For access to S3, IAM, and CloudFront"
+  cdn-broker.aws_secret_access_key:
+    description: "For access to S3, IAM, and CloudFront"
+  cdn-broker.aws_region:
+    description: "AWS CDN Region"
+    default: "eu-west-1"
+  cdn-broker.server_side_encryption:
+    description: "Server side encryption"
+    default: "AES256"
+  cdn-broker.api_address:
+    description: "CloudFoundry API address for the CLI. The broker will check if the domain has been created and if it really belongs to the org creating the service"
+  cdn-broker.client_id:
+    description: "Credentials for obtaining org and domain details"
+  cdn-broker.client_secret:
+    description: "Credentials for obtaining org and domain details"
+  cdn-broker.default_origin:
+    description: "Default origin. e.g. example.com"
+  cdn-broker.schedule:
+    description: "Cron schedlue for checking if cert renewal is required"
+    default: "0 0 * * * *"

--- a/jobs/cdn-cron/templates/bin/cdn-cron-ctl.erb
+++ b/jobs/cdn-cron/templates/bin/cdn-cron-ctl.erb
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Setup common env vars and folders
+source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'cdn-cron'
+export CDN_CRON_PID_FILE=${CDN_CRON_PID_DIR}/cdn-cron.pid
+
+case $1 in
+
+  start)
+    pid_guard ${CDN_CRON_PID_FILE} ${JOB_NAME}
+    echo $$ > ${CDN_CRON_PID_FILE}
+
+    # Start CDN Cron service
+    exec /var/vcap/packages/cdn-broker/bin/cdn-cron \
+      > >(tee -a ${CDN_CRON_LOG_DIR}/${OUTPUT_LABEL}.stdout.log | logger -t vcap.${OUTPUT_LABEL}.stdout) \
+      2> >(tee -a ${CDN_CRON_LOG_DIR}/${OUTPUT_LABEL}.stderr.log | logger -t vcap.${OUTPUT_LABEL}.stderr)
+    ;;
+
+  stop)
+    # Stop CDN Cron service
+    kill_and_wait ${CDN_CRON_PID_FILE}
+    ;;
+
+  *)
+    echo "Usage: $0 {start|stop}"
+    exit 1
+    ;;
+
+esac
+exit 0

--- a/jobs/cdn-cron/templates/bin/job_properties.sh.erb
+++ b/jobs/cdn-cron/templates/bin/job_properties.sh.erb
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
 
 #
-# CDN Broker properties
+# CDN Cron properties
 #
 
-# Directory to store the CDN Broker configuration files
-export CDN_BROKER_CONF_DIR=${JOB_DIR}/config
+# Directory to store the CDN Cron configuration files
+export CDN_CRON_CONF_DIR=${JOB_DIR}/config
 
-# Directory to store the CDN Broker log files
-export CDN_BROKER_LOG_DIR=${LOG_DIR}
+# Directory to store the CDN Cron log files
+export CDN_CRON_LOG_DIR=${LOG_DIR}
 
-# Directory to store the CDN Broker process IDs
-export CDN_BROKER_PID_DIR=${RUN_DIR}
+# Directory to store the CDN Cron process IDs
+export CDN_CRON_PID_DIR=${RUN_DIR}
 
-# Directory to store the CDN Broker data files
-export CDN_BROKER_STORE_DIR=${STORE_DIR}
+# Directory to store the CDN Cron data files
+export CDN_CRON_STORE_DIR=${STORE_DIR}
 
-# Directory to store the CDN Broker temp files
-export CDN_BROKER_TMP_DIR=${TMP_DIR}
+# Directory to store the CDN Cron temp files
+export CDN_CRON_TMP_DIR=${TMP_DIR}
 
-# These properties are duplicated in the cdn-cron job
+# These properties are duplicated in the cdn-broker job
 export CDN_PORT="<%= p('cdn-broker.port') %>"
 export CDN_BROKER_USERNAME="<%= p('cdn-broker.broker_username') %>"
 export CDN_BROKER_PASSWORD="<%= p('cdn-broker.broker_password') %>"


### PR DESCRIPTION
## What

We haven't been running the cron process for managing certificate renewals, so we add it to the Bosh release here. See commit message for full details.

## How to review

* code review
* you can deploy it using the `cdn-cron` branch of paas-cf, which once this is merged will be updated to point to the new build of this release. We expect this to only run one instance of the cdn-cron job, to avoid race conditions in the renewal of certificates.
* [deploy a CDN](https://docs.cloud.service.gov.uk/#using-a-custom-domain).
* check it renews certificates:

  We found the broker uses the certificate expiry date in its database, not in the certificate itself, to determine whether it needs to renew it. This means you can test the renewal by changing the `expires` field in the `certificates` table to a date which is less than 30 days in the future. I created [a helper script](https://gist.github.com/henrytk/4b2e0ca67c0a5c676bebbeddd3f5de24) for logging into the database.

## Who

Anyone but me or @bandesz 