### PR TITLE
[Support] Remove additional `*` from cron

### DIFF
--- a/jobs/cdn-broker/spec
+++ b/jobs/cdn-broker/spec
@@ -50,4 +50,4 @@ properties:
     description: "Default origin. e.g. example.com"
   cdn-broker.schedule:
     description: "Cron schedlue for checking if cert renewal is required"
-    default: "0 0 * * * *"
+    default: "0 0 * * *"


### PR DESCRIPTION
## What

There was an additional `*` in the default cron which caused the
certificate renewal to run once per hour.

## How to review

Code review

## Who can review?

Not @LeePorte