### PR TITLE
Bump submodule for logging, upgrade to Go 1.12

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,5 +1,5 @@
 ---
-golang/go1.8.linux-amd64.tar.gz:
-  object_id: 5246bccf-2d59-415c-a277-614054a11ed9
-  sha: a93fe8fc245e3554f956bc823f30ef4eb23c2068
-  size: 89803580
+golang/go1.12.linux-amd64.tar.gz:
+  size: 127228112
+  object_id: 02e5a003-19ba-4ac3-6719-e44c8ad6ec03
+  sha: 8715ddcd08e9d5ddf3e09c1af7c69bf4f23847ae

--- a/packages/cdn-broker/packaging
+++ b/packages/cdn-broker/packaging
@@ -5,6 +5,10 @@ set -u # report the usage of uninitialized variables
 export GOROOT=$(readlink -nf /var/vcap/packages/golang)
 export PATH=${GOROOT}/bin:${PATH}
 
+# Set Go cache
+export GOCACHE=/tmp/gocache/cdn-broker
+mkdir -p $GOCACHE
+
 # Build CDN Service Broker package
 echo "Building CDN Service Broker..."
 PACKAGE_NAME=github.com/18F/cf-cdn-service-broker

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -2,4 +2,4 @@
 name: golang
 dependencies: []
 files:
-  - golang/go1.8.linux-amd64.tar.gz
+  - golang/go1.12.linux-amd64.tar.gz


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/n/projects/1275640/stories/164986888)

Bump CDN broker to include more logging

Includes:

- alphagov/paas-cdn-broker#16
- alphagov/paas-cdn-broker#17
- alphagov/paas-cdn-broker#19

In PR 16 the version of Go was updated, and `go mod` was used. So I updated this bosh release so it would build.